### PR TITLE
Redirect to new Xdev site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to https://ncar.github.io/esds/</title>
-<meta http-equiv="refresh" content="0; URL=https://ncar.github.io/esds/">
-<link rel="canonical" href="https://ncar.github.io/esds/">
+<title>Redirecting to https://ncar-xdev.github.io</title>
+<meta http-equiv="refresh" content="0; URL=https://ncar-xdev.github.io">
+<link rel="canonical" href="https://ncar-xdev.github.io">


### PR DESCRIPTION
This changes the redirect of the main Xdev page to the new main Xdev page, but it keeps the old redirects for the blog posts pointing to the ESDS blog (where they have been moved).